### PR TITLE
Better C interop support

### DIFF
--- a/ChronCompiler/Chron.g4
+++ b/ChronCompiler/Chron.g4
@@ -100,7 +100,7 @@ STRING: ('"' (ESC | ~'"')* '"');
 fragment ESC      : '\\' . ;
 BOOLEAN: 'false' | 'true';
 
-IDENTIFIER: [a-zA-Z0-9_][a-zA-Z0-9_.]*;
+IDENTIFIER: [a-zA-Z_][a-zA-Z0-9_.]*;
 
 WHITESPACE: (' ' | '\t' | '\r' | '\n') -> skip;
 COMMENT: '//' ~[\r\n]* -> skip;

--- a/ChronCompiler/core/c.chron
+++ b/ChronCompiler/core/c.chron
@@ -1,3 +1,23 @@
-$("return")
+$("native")
+$("return"="int")
 $("name"="c.int")
-c_int :: (object) ?
+$("parameters"="ChronObject o")
+!c_int :: (object) ?
+
+$("native")
+$("return"="const char*")
+$("name"="c.string")
+$("parameters"="ChronObject o")
+!c_string :: (object) ?
+
+$("native")
+$("return"="bool")
+$("name"="c.bool")
+$("parameters"="ChronObject o")
+!c_bool :: (object) ?
+
+$("native")
+$("return"="ChronObject")
+$("name"="c.fromInt")
+$("parameters"="int i")
+!DynInteger :: (object) ?

--- a/ChronCompiler/core/c.chron
+++ b/ChronCompiler/core/c.chron
@@ -21,3 +21,15 @@ $("return"="ChronObject")
 $("name"="c.fromInt")
 $("parameters"="int i")
 !DynInteger :: (object) ?
+
+$("native")
+$("return"="ChronObject")
+$("name"="c.fromString")
+$("parameters"="const char* s")
+!DynString :: (object) ?
+
+$("native")
+$("return"="ChronObject")
+$("name"="c.fromBool")
+$("parameters"="bool b")
+!DynBoolean :: (object) ?

--- a/ChronIR/Backend/standard.c
+++ b/ChronIR/Backend/standard.c
@@ -443,3 +443,19 @@ void ReleaseMemoryContext(ChronObject o)
 	MemoryContext *ctx = obj->ptr;
 	MemoryContext_ReleaseContext(ctx);
 }
+
+int c_int(ChronObject o)
+{
+	DynObject *obj = o->Object;
+	return obj->integer;
+}
+const char *c_string(ChronObject o)
+{
+	DynObject *obj = o->Object;
+	return obj->str;
+}
+bool c_bool(ChronObject o)
+{
+	DynObject *obj = o->Object;
+	return obj->boolean;
+}

--- a/ChronIR/Backend/standard.h
+++ b/ChronIR/Backend/standard.h
@@ -28,6 +28,9 @@ void ReleaseMemoryContext(ChronObject o);
 void SetMemoryContext();
 void Throw(ChronObject errorMessage);
 bool GetBoolean(ChronObject o);
+int c_int(ChronObject o);
+const char* c_string(ChronObject o);
+bool c_bool(ChronObject o);
 
 #define ref(o) (&o)
 #define deref(o) (*o)

--- a/ChronIR/Backend/standard.h
+++ b/ChronIR/Backend/standard.h
@@ -29,7 +29,7 @@ void SetMemoryContext();
 void Throw(ChronObject errorMessage);
 bool GetBoolean(ChronObject o);
 int c_int(ChronObject o);
-const char* c_string(ChronObject o);
+const char *c_string(ChronObject o);
 bool c_bool(ChronObject o);
 
 #define ref(o) (&o)

--- a/ChronIR/IR/Internal/ChronTypes.cs
+++ b/ChronIR/IR/Internal/ChronTypes.cs
@@ -29,5 +29,19 @@
         public static string SetDynamicTable = "SetDynamicTable";
         public static string GCRelease = "MemoryContext_Release";
         public static int TEMP_VARIABLE = 0;
+        public static Dictionary<string, int> DefinedFunctions = new();
+        public static string DefineFunction(string Name)
+        {
+            if (ChronTypes.DefinedFunctions.ContainsKey(Name))
+                ChronTypes.DefinedFunctions[Name] += 1;
+            else
+                ChronTypes.DefinedFunctions[Name] = 0;
+            if (ChronTypes.DefinedFunctions[Name] > 0)
+            {
+                return $"{Name}{ChronTypes.DefinedFunctions[Name]}";
+            }
+
+            return Name;
+        }
     }
 }


### PR DESCRIPTION
You can now easily interop with basic typed (int, const char*, bool) c functions

Here's an example


```chron
include core.c

$("native")
$("return"="int")
$("parameters"="int a, int b")
sum :: (a, b) {
    return c.int( c.fromInt(a) + c.fromInt(b) )
}

main :: {
    result = c.fromInt(sum(c.int(10), c.int(5)))
    PrintLn(result)
}```